### PR TITLE
Fix deprecation warning: change .setDefaults() to .config()

### DIFF
--- a/app/assets/javascripts/zeroclipboard/asset-path.js.erb
+++ b/app/assets/javascripts/zeroclipboard/asset-path.js.erb
@@ -1,1 +1,1 @@
-ZeroClipboard.setDefaults( { moviePath: '<%= asset_path 'ZeroClipboard.swf' %>' }  );
+ZeroClipboard.config( { moviePath: '<%= asset_path 'ZeroClipboard.swf' %>' }  );


### PR DESCRIPTION
Resolved the deprecation warning in the JS console for `v1.3.x`:

```
`ZeroClipboard.setDefaults` is deprecated. See docs for more info:
https://github.com/zeroclipboard/zeroclipboard/blob/master/docs/instructions.md#deprecations
```
