### PR TITLE
add depend_on_asset to asset-path.js

### DIFF
--- a/app/assets/javascripts/zeroclipboard/asset-path.js.erb
+++ b/app/assets/javascripts/zeroclipboard/asset-path.js.erb
@@ -1,1 +1,2 @@
+//= depend_on_asset "ZeroClipboard.swf"
 ZeroClipboard.config( { moviePath: '<%= asset_path 'ZeroClipboard.swf' %>' }  );


### PR DESCRIPTION
This might not be necessary, but it will ensure asset-path is recompiled by the asset pipeline when the swf file changes, as well as prevent dependency errors being raised by https://github.com/schneems/sprockets_better_errors
