### PR TITLE
fix(asset-path): use more specific image_path instead of asset_path

### DIFF
--- a/app/assets/javascripts/zeroclipboard/asset-path.js.erb
+++ b/app/assets/javascripts/zeroclipboard/asset-path.js.erb
@@ -1,2 +1,4 @@
 //= depend_on_asset "ZeroClipboard.swf"
-ZeroClipboard.config( { swfPath: '<%= asset_path 'ZeroClipboard.swf' %>' }  );
+ZeroClipboard.config({
+  swfPath: '<%= image_path "ZeroClipboard.swf" %>'
+});


### PR DESCRIPTION
So that other build tools like `middleman` can access it.
