### PR TITLE
tweak swfPath config for js module definitions

### DIFF
--- a/app/assets/javascripts/zeroclipboard/asset-path.js.erb
+++ b/app/assets/javascripts/zeroclipboard/asset-path.js.erb
@@ -1,4 +1,18 @@
 //= depend_on_asset "ZeroClipboard.swf"
-ZeroClipboard.config({
-  swfPath: '<%= image_path "ZeroClipboard.swf" %>'
-});
+(function(window, undefined) {
+  "use strict";
+  var settings = {
+    swfPath: '<%= image_path "ZeroClipboard.swf" %>'
+  };
+  if (typeof define === "function" && define.amd) {
+    require(["ZeroClipboard"], function(ZeroClipboard) {
+      ZeroClipboard.config(settings);
+    });
+  } else if (typeof module === "object" && module && typeof module.exports === "object" && module.exports) {
+    require("ZeroClipboard").config(settings);
+  } else {
+    window.ZeroClipboard.config(settings);
+  }
+})(function() {
+  return this || window;
+}());

--- a/app/assets/javascripts/zeroclipboard/asset-path.js.erb
+++ b/app/assets/javascripts/zeroclipboard/asset-path.js.erb
@@ -2,7 +2,7 @@
 (function(window, undefined) {
   "use strict";
   var settings = {
-    swfPath: '<%= image_path "ZeroClipboard.swf" %>'
+    swfPath: <%= image_path("ZeroClipboard.swf").to_json %>
   };
   if (typeof define === "function" && define.amd) {
     require(["ZeroClipboard"], function(ZeroClipboard) {


### PR DESCRIPTION
If `ZeroClipboard` is not in scope when `asset-path.js.erb` is being run, it will error out with `ZeroClipboard is not defined` when it tries to set `ZeroClipboard.config({ swfPath: '...' })`.

This is currently only tested with requirejs-rails, which the first conditional addresses.