### PR TITLE
Use image_url instead of image_path

### DIFF
--- a/app/assets/javascripts/zeroclipboard/asset-path.js.erb
+++ b/app/assets/javascripts/zeroclipboard/asset-path.js.erb
@@ -1,4 +1,4 @@
 //= depend_on_asset "ZeroClipboard.swf"
 ZeroClipboard.config({
-  swfPath: '<%= image_path "ZeroClipboard.swf" %>'
+  swfPath: '<%= image_url "ZeroClipboard.swf" %>'
 });


### PR DESCRIPTION
In our Rails app we have assets host different than the app host.

In Rails assets host can be configured for each environment as such:
```
config.action_controller.asset_host = "http://assets.someapp.com"
```

If we use ```image_path``` to generate swf url, we have output as such: "http://www.someapp.com/assets/ZeroClipboard.swf".

What should be is the path "http://assets.someapp.com/assets/ZeroClipboard.swf".

If we use ```image_url``` instead, it will solve the problem.