### PR TITLE
Disable ZeroClipboard's cache busting when using Rails asset digests

### DIFF
--- a/app/assets/javascripts/zeroclipboard/asset-path.js.erb
+++ b/app/assets/javascripts/zeroclipboard/asset-path.js.erb
@@ -1,4 +1,8 @@
 //= depend_on_asset "ZeroClipboard.swf"
-ZeroClipboard.config({
-  swfPath: '<%= image_path "ZeroClipboard.swf" %>'
-});
+<%
+  config = {
+    cacheBust: !Rails.configuration.assets.digest,
+    swfPath: image_path("ZeroClipboard.swf")
+  }
+%>
+ZeroClipboard.config(<%= config.to_json %>);


### PR DESCRIPTION
When using Rails asset digests, `ZeroClipboard.swf` becomes something like `ZeroClipboard-abcd1234ef.swf` and is referenced as such through the `swfPath` config option, set by zeroclipboard-rails.

However, ZeroClipboard also includes its own cache busting mechanism: adding a `noCache` query param that sends the current timestamp. This is not necessary when using Rails asset digests.

ZeroClipboard offers a config option to disable `noCache` that we should set to `false` when using asset digests. Here is a PR for that. :)

If you're uncomfortable with my changes using `to_json`, this is maybe less invasive:
```diff
 //= depend_on_asset "ZeroClipboard.swf"
 ZeroClipboard.config({
+  noCache: <%= Rails.configuration.assets.digest ? 'true' : 'false' %>,
   swfPath: '<%= image_path "ZeroClipboard.swf" %>'
 });
```